### PR TITLE
Ensure Python{2,3} compatibility with Python3 input

### DIFF
--- a/dqmio/commissioning/check_dataset_size_submit.py
+++ b/dqmio/commissioning/check_dataset_size_submit.py
@@ -8,6 +8,11 @@
 import sys
 import os
 import argparse
+
+# Make the code work for both python 2 and 3
+# Use input from Python 3
+from six.moves import input
+
 sys.path.append('../../jobsubmission')
 import condortools as ct
 sys.path.append('../src')
@@ -51,8 +56,7 @@ if __name__=='__main__':
   for d in datasetnames: print('  - {}'.format(d))
   
   # ask for confirmation to continue
-  print('Continue? (y/n)')
-  go = input()
+  go = input('Continue? (y/n) ')
   if not go=='y': sys.exit()
 
   # loop over datasets

--- a/dqmio/copydastolocal/copy_das_to_local_set.py
+++ b/dqmio/copydastolocal/copy_das_to_local_set.py
@@ -11,6 +11,11 @@
 import sys
 import os
 import argparse
+
+# Make the code work for both python 2 and 3
+# Use input from Python 3
+from six.moves import input
+
 sys.path.append('../src/')
 from tools import format_input_files, export_proxy
 sys.path.append('../../jobsubmission')
@@ -91,8 +96,7 @@ if __name__=='__main__':
 
   # ask for confirmation
   print('Found {} files to download into {}'.format(len(dasfiles),outputdir))
-  print('Proceed? (y/n)')
-  go = raw_input()
+  go = input('Proceed? (y/n) ')
   if go!='y': sys.exit()
 
   # make the commands

--- a/dqmio/utils/plot_mes.py
+++ b/dqmio/utils/plot_mes.py
@@ -13,6 +13,11 @@ import json
 import argparse
 from fnmatch import fnmatch
 import matplotlib.pyplot as plt
+
+# Make it work under both python 2 and 3
+# Use input from Python 3
+from six.moves import input
+
 sys.path.append('../src')
 from DQMIOReader import DQMIOReader
 import tools
@@ -186,8 +191,7 @@ if __name__=='__main__':
 
   # check number of selected histograms
   nplots = nmes*nlumis
-  print('{} plots will be made; continue with plotting? (y/n)'.format(nplots))
-  go = raw_input()
+  go = input('{} plots will be made; continue with plotting? (y/n) '.format(nplots))
   if go!='y': sys.exit()
 
   # make plots

--- a/dqmioprod/testing/check_nlumis_das.py
+++ b/dqmioprod/testing/check_nlumis_das.py
@@ -6,6 +6,10 @@ import sys
 import os
 import argparse
 
+# Make it work under both python 2 and 3
+# Use input from Python 3
+from six.moves import input
+
 if __name__=='__main__':
 
   # read arguments
@@ -29,8 +33,7 @@ if __name__=='__main__':
   for dataset in datasets: print('  - {}'.format(dataset))
 
   # check if need to continue
-  print('Continue to find number of lumisections for these datasets? (y/n)')
-  go = raw_input()
+  go = input('Continue to find number of lumisections for these datasets? (y/n) ')
   if not go=='y': sys.exit()
 
   # find number of lumisections for each dataset

--- a/omsinterface/get_oms_data.py
+++ b/omsinterface/get_oms_data.py
@@ -15,7 +15,11 @@ import sys
 import os
 import json
 from getpass import getpass
+
 import importlib
+# Make the code work for both python 2 and 3
+# Use input from Python 3
+from six.moves import input
 
 # local modules
 import omstools


### PR DESCRIPTION
This patch ensures that the `input` function works on both Python 2 and Python 3, by using the `input` function from the external module `six.moves` which behaves like the Python3 `input`.


|   | Read as string (recommended) | Evaluate the string read (vulnerable) |
|-|-|-|
| Python 2 | `raw_input()` | `input()` |
| Python 3 | `input()` | `eval(input())` |

The Python package "six" is widely used to ensure cross-Python-version compatibility and is available on LXPLUS.

Before this patch, the use of input and raw_input is inconsistent across *.py files in this project, causing error when trying to run the whole project on any of the Python version. Fix such inconsistency here.

It would be necessary to ensure Python3 compatibility because
1.  Python 2 is officially declared end-of-life, and newer versions of NumPy (e.g. the one on LXPLUS8) already dropped their Python2 support.
2.  The Jupyter notebooks in this repository is run on Python 3 kernels (based on the metadata).

Status:

The reading part of [the nanoDQM tutorial](https://indico.cern.ch/event/1212349/contributions/5139086/attachments/2559259/4410743/nanodqmio_workshop_20221202.pdf) has been tested. I don't know how to test the execution of other Python script.

Nevertheless, the change should be trivial enough to work on all of the scripts.

Additional work:

Simplify the code with

```python
go = input("Confirmation (y/n) ")
```

instead of

```python
print("Confirmation (y/n)")
go = input()
```