### PR TITLE
DQMIOReader: make `pandas` import optional and categorize module imports

### DIFF
--- a/dqmio/src/DQMIOReader.py
+++ b/dqmio/src/DQMIOReader.py
@@ -5,12 +5,9 @@
 
 ### imports
 
+## Python standard library
+
 import sys
-import ROOT
-import numpy as np
-#import root_numpy
-# disable temporary since not available on SWAN, for now just define manual conversion function from root to numpy array
-# note: root_numpy provides an efficient interface between ROOT and numpy
 from fnmatch import fnmatch 
 # note: fnmatch provides support for unix shell-style wildcards, which are not the same as regular expressions in python
 from collections import namedtuple
@@ -21,10 +18,16 @@ from collections import defaultdict
 from multiprocessing.pool import ThreadPool
 # note: ThreadPool is used for parallel processing, calling the same function on parallel inputs 
 #       and collecting the results in a list
-
 from timeit import default_timer
 # note: only used for callback method to print the progress of getSingleMes
 
+## third-party
+
+import ROOT
+import numpy as np
+#import root_numpy
+# disable temporary since not available on SWAN, for now just define manual conversion function from root to numpy array
+# note: root_numpy provides an efficient interface between ROOT and numpy
 import pandas as pd
 # note: only used for conversion into dataframe
 

--- a/dqmio/src/DQMIOReader.py
+++ b/dqmio/src/DQMIOReader.py
@@ -28,7 +28,13 @@ import numpy as np
 #import root_numpy
 # disable temporary since not available on SWAN, for now just define manual conversion function from root to numpy array
 # note: root_numpy provides an efficient interface between ROOT and numpy
-import pandas as pd
+
+pandas_import_error = None
+try:
+    import pandas as pd
+except ImportError as e:
+    pandas_import_error = e
+    pd = None
 # note: only used for conversion into dataframe
 
 
@@ -432,7 +438,10 @@ class DQMIOReader:
     def getSingleMEsToDataFrame(self, name, verbose=False):
         ### return a pandas dataframe for a given monitoring element
         # note: the same naming convention is used as in the 2017/2018 csv input!
-        
+
+        if not pd:
+            raise pandas_import_error
+
         # get the monitoring elements
         callback = None
         if verbose: callback='default'


### PR DESCRIPTION
This PR makes `pandas` module optional, and throw module import error only when calling the method `getSingleMEsToDataFrame()`. `import pandas` is still done globally, in case we would like to add [type hints](https://peps.python.org/pep-0484/) for the output type of `getSingleMEsToDataFrame()` in the future.

This PR also separate modules from third-party packages from those from Python Standard Library for `DQMIOReader.py` to make its dependency requirement more discoverable.