### PR TITLE
treewide: use built-in bool instead of np.bool

### DIFF
--- a/src/HistStruct.py
+++ b/src/HistStruct.py
@@ -411,7 +411,7 @@ class HistStruct(object):
         if(np.amax(indices)>=len(self.lsnbs)):
             raise Exception('ERROR in HistStruct.add_index_mask: largest index is {}'.format(np.amax(indices))
                            +' but there are only {} lumisections in the HistStruct'.format(len(self.lsnbs)))
-        mask = np.zeros(len(self.lsnbs), dtype=np.bool)
+        mask = np.zeros(len(self.lsnbs), dtype=bool)
         mask[indices] = True
         self.add_mask( name, mask)
         

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -102,7 +102,7 @@ def injson( run, lumi, jsonfile=None, jsondict=None ):
     # check for all run/lumi combinations if they are in the json object
     for i,(r,l) in enumerate(zip(run,lumi)):
         if injson_single( r, l, jsondict ): res[i]=1
-    res = res.astype(np.bool)
+    res = res.astype(bool)
     if len(res)==1: res = res[0]
     return res
 


### PR DESCRIPTION
Use built-in bool type instead of np.bool, as np.bool "was a deprecated alias of bool". AttributeError with the following message are thrown when accessing np.bool on a newer version of NumPy:

AttributeError: module 'numpy' has no attribute 'bool'.

`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations.

Did you mean: 'bool_'?