### PR TITLE
Updated OMS API URL

### DIFF
--- a/omsapi/urls.py
+++ b/omsapi/urls.py
@@ -1,6 +1,6 @@
 # **Definition of URLs to be used for the API queries**
 
-API_URL = 'https://vocms0185.cern.ch/agg/api'
+API_URL = 'https://cmsoms.cern.ch/agg/api'
 API_VERSION = 'v1'
 API_AUDIENCE = 'cmsoms-int-0185'
 


### PR DESCRIPTION
Hi Luka,

I have just rerun my OMS rate retriever code and found out that the URL referenced in `urls.py` is now outdated. In this PR I simply updated the URL to `https://cmsoms.cern.ch/agg/api/v1/...`

Should we require our hackathon participants to use our OMS data retriever, this fix would be essential. I have also tested this fix and it works so far.

As always, please let me know what you think.

Thanks!
Vichayanun