### PR TITLE
dfu.get_hist_values(): support DIALS 2023 and 2024 data format and non-zero starting index

### DIFF
--- a/utils/dataframe_utils.py
+++ b/utils/dataframe_utils.py
@@ -147,7 +147,7 @@ def get_hist_values(df, datacolumn='data', xbinscolumn='xbins', ybinscolumn='ybi
     #       update: 'ybins' is also present for 1D histograms, but has value 1!
     # output:
     # a tuple containing the following elements:
-    # - np array of shape (nhists,nbins) (for 1D) or (nhists,nybins,nxbins) (for 2D)
+    # - np array of shape (nhists,nbins) (for 1D) or (nhists,nybins,nxbins) (for 2D), with underflow and overflow bins
     # - np array of run numbers of length nhists
     # - np array of lumisection numbers of length nhists
     # warning: no check is done to assure that all histograms are of the same type!

--- a/utils/dataframe_utils.py
+++ b/utils/dataframe_utils.py
@@ -16,6 +16,7 @@ import pandas as pd
 import numpy as np
 import json
 import importlib
+from warnings import warn
 
 # local modules
 import json_utils
@@ -151,7 +152,12 @@ def get_hist_values(df, datacolumn='data', xbinscolumn='xbins', ybinscolumn='ybi
     # - np array of run numbers of length nhists
     # - np array of lumisection numbers of length nhists
     # warning: no check is done to assure that all histograms are of the same type!
-    
+
+    # check if the input dataset is of no records
+    if not len(df):
+        warn("get_hist_values: Input dataframe contains no records", UserWarning, stacklevel=2)
+        return (None, np.empty((0,), dtype=int), np.empty((0,), dtype=int))
+
     # check for corruption of data types (observed once after merging several csv files)
     if isinstance( df.at[0,xbinscolumn], str ):
         raise Exception('ERROR in dataframe_utils.py / get_hist_values:'


### PR DESCRIPTION
This pull fixes `dfu.get_hist_values()` support to DataFrames from DILAS for 2023 and 2024 datasets. The fixes include:
-   Handle the alternative, multiple-spaces-separated data string format
-   Handle the data strings that lack underflow and overflow bins.
-   Detect the format and define the processing in advance instead of try-catching for each row.
-   Broadcast the histogram bins straight into `vals`, avoiding intermediate NumPy arrays.

This pull request also handles zero-row DataFrames and DataFrames whose first index is not 0.
-   Handle the zero-row input DataFrame with a warning and return with `vals` equal `None`, balancing handlable edge cases and fast failing.
-   Assign the index of the first column to `i0` and use `i0` to access the first row and `range(i0, i0 + len(df))` for iterating over rows instead of the hard-coded `0` and `range(len(df)).`

The changes are tested locally with the following datasets from workspace `jetmet` for monitoring element `JetMET/MET/pfMetPuppi/Cleaned/METSig` stored in CSV format:

| Tool | Dataset |
|-----------|---------|
| [dqmiotools](https://github.com/LukaLambrecht/dqmiotools) (legacy) | [`/JetMET0/Run2023D-PromptReco-v1/DQMIO`](https://cmsweb.cern.ch/das/request?input=dataset%3D%2FJetMET0%2FRun2023D-PromptReco-v1%2FDQMIO&instance=prod/global) |
| [DIALS Python client](https://github.com/cms-DQM/dials-py) | [`/JetMET0/Run2023D-PromptReco-v1/DQMIO`](https://cmsweb.cern.ch/das/request?input=dataset%3D%2FJetMET0%2FRun2023D-PromptReco-v1%2FDQMIO&instance=prod/global) |
| [DIALS Python client](https://github.com/cms-DQM/dials-py) |[`/JetMET0/Run2024D-PromptReco-v1/DQMIO`](https://cmsweb.cern.ch/das/request?input=dataset%3D%2FJetMET0%2FRun2024D-PromptReco-v1%2FDQMIO&instance=prod/global) |